### PR TITLE
Timber blocks dropping at location of the log broken

### DIFF
--- a/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
@@ -61,7 +61,7 @@ public class TimberListener implements Listener {
                 .collect(Collectors.groupingBy(ItemStack::getType, Collectors.summingInt(ItemStack::getAmount)));
 
         consolidatedDrops.forEach((material, amount) -> {
-            player.getWorld().dropItemNaturally(player.getLocation(), new ItemStack(material, amount));
+            player.getWorld().dropItemNaturally(block.getLocation(), new ItemStack(material, amount));
         });
     }
 

--- a/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/enchantments/TimberListener.java
@@ -66,7 +66,7 @@ public class TimberListener implements Listener {
     }
 
     private boolean isLog(Material type) {
-        return type.name().contains("LOG") || type.name().contains("WOOD") || type.name().contains("STEM");
+        return type.name().contains("LOG") || type.name().contains("WOOD") || type.name().contains("STEM") || type.name().contains("HYPHAE");
     }
 
     private void destroyTree(Block block, List<ItemStack> drops, AtomicInteger blocksDestroyed, Set<Block> checkedBlocks, Player player) {


### PR DESCRIPTION
To make behavior more inline and uniform with VeinMiner, the logs, wood, stems and hyphae now drop at the location of which the player broke, instead of on top of the player.

Because of the random velocity that gets added to the dropped item when its broken, if it is spawned on the player, there can be a bit of confusion as to where the logs (or log variants) went if the blocks get sent behind the player.