### PR TITLE
Switch from trusts to player-settings yml

### DIFF
--- a/src/main/java/plugins/nate/smp/SMP.java
+++ b/src/main/java/plugins/nate/smp/SMP.java
@@ -11,7 +11,7 @@ import org.bukkit.plugin.java.JavaPlugin;
 import plugins.nate.smp.managers.ElytraGlidingTracker;
 import plugins.nate.smp.managers.EnchantmentManager;
 import plugins.nate.smp.managers.RecipeManager;
-import plugins.nate.smp.managers.TrustManager;
+import plugins.nate.smp.managers.PlayerSettingsManager;
 import plugins.nate.smp.utils.*;
 
 import java.io.File;
@@ -35,7 +35,7 @@ public final class SMP extends JavaPlugin {
         plugin = this;
         coreProtect = SMPUtils.loadCoreProtect();
 
-        TrustManager.init(this.getDataFolder());
+        PlayerSettingsManager.init(this.getDataFolder());
 
         DependencyUtils.checkDependencies();
         EventRegistration.registerEvents(this);

--- a/src/main/java/plugins/nate/smp/commands/SMPCommand.java
+++ b/src/main/java/plugins/nate/smp/commands/SMPCommand.java
@@ -12,7 +12,7 @@ import org.bukkit.command.TabCompleter;
 import org.bukkit.entity.Player;
 import org.bukkit.persistence.PersistentDataType;
 import org.jetbrains.annotations.NotNull;
-import plugins.nate.smp.managers.TrustManager;
+import plugins.nate.smp.managers.PlayerSettingsManager;
 import plugins.nate.smp.utils.ChatUtils;
 import plugins.nate.smp.utils.SMPUtils;
 import plugins.nate.smp.utils.TellerUtils;
@@ -64,7 +64,7 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
                     return Collections.emptyList();
                 }
 
-                return TrustManager.getTrustedPlayerNames(player.getUniqueId()).stream()
+                return PlayerSettingsManager.getTrustedPlayerNames(player.getUniqueId()).stream()
                         .map(String::toLowerCase)
                         .filter(trustedPlayerName -> trustedPlayerName.startsWith(args[1].toLowerCase()))
                         .sorted()
@@ -210,9 +210,9 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
 
         boolean updated;
         if (action.equals("trust")) {
-            updated = TrustManager.trustPlayer(player, target);
+            updated = PlayerSettingsManager.trustPlayer(player, target);
         } else {
-            updated = TrustManager.untrustPlayer(player, target);
+            updated = PlayerSettingsManager.untrustPlayer(player, target);
         }
 
         if (updated) {
@@ -227,7 +227,7 @@ public class SMPCommand implements CommandExecutor, TabCompleter {
             return;
         }
 
-        Set<UUID> trustedPlayers = TrustManager.getTrustedPlayers(player.getUniqueId());
+        Set<UUID> trustedPlayers = PlayerSettingsManager.getTrustedPlayers(player.getUniqueId());
         if (trustedPlayers.isEmpty()) {
             sendMessage(player, ChatUtils.PREFIX + "&cYou have not trusted any players");
             return;

--- a/src/main/java/plugins/nate/smp/listeners/AntiEntityGriefListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/AntiEntityGriefListener.java
@@ -14,7 +14,7 @@ import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.persistence.PersistentDataType;
-import plugins.nate.smp.managers.TrustManager;
+import plugins.nate.smp.managers.PlayerSettingsManager;
 import plugins.nate.smp.utils.ChatUtils;
 import plugins.nate.smp.utils.SMPUtils;
 
@@ -251,7 +251,7 @@ public class AntiEntityGriefListener implements Listener {
             }
 
             UUID ownerUUID = getEntityOwner(e.getRightClicked());
-            Set<UUID> trustedPlayersUUID = TrustManager.getTrustedPlayers(ownerUUID);
+            Set<UUID> trustedPlayersUUID = PlayerSettingsManager.getTrustedPlayers(ownerUUID);
             if (ownerUUID != null && !e.getPlayer().getUniqueId().equals(ownerUUID) && !trustedPlayersUUID.contains(e.getPlayer().getUniqueId())) {
                 String ownerName = Bukkit.getOfflinePlayer(ownerUUID).getName();
                 sendMessage(e.getPlayer(), ChatUtils.PREFIX + "&cError: " + ownerName + " has claimed this entity and has disabled trading!");

--- a/src/main/java/plugins/nate/smp/listeners/ChestLockListener.java
+++ b/src/main/java/plugins/nate/smp/listeners/ChestLockListener.java
@@ -14,7 +14,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.DoubleChestInventory;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.persistence.PersistentDataType;
-import plugins.nate.smp.managers.TrustManager;
+import plugins.nate.smp.managers.PlayerSettingsManager;
 import plugins.nate.smp.utils.SMPUtils;
 
 import java.util.Arrays;
@@ -268,7 +268,7 @@ public class ChestLockListener implements Listener {
 
         UUID ownerUUID = getLockedSignOwner(attachedSign);
 
-        Set<UUID> trustedPlayersUUID = TrustManager.getTrustedPlayers(ownerUUID);
+        Set<UUID> trustedPlayersUUID = PlayerSettingsManager.getTrustedPlayers(ownerUUID);
         return player.getUniqueId().equals(ownerUUID) || trustedPlayersUUID.contains(player.getUniqueId());
     }
 

--- a/src/main/java/plugins/nate/smp/managers/PlayerSettingsManager.java
+++ b/src/main/java/plugins/nate/smp/managers/PlayerSettingsManager.java
@@ -93,12 +93,6 @@ public class PlayerSettingsManager {
         }
     }
 
-    /**
-     *
-     * @param trustsFile
-     * @param settingsFile
-     * @return If the file save succeeded
-     */
     private static void convertTrustsYML(File trustsFile, File settingsFile) {
         YamlConfiguration trustsConfig = YamlConfiguration.loadConfiguration(trustsFile);
         YamlConfiguration settingsConfig = YamlConfiguration.loadConfiguration(settingsFile);


### PR DESCRIPTION
**Changes**
To plan for additional settings to be added to this YML, the `trusts.yml`:
![image](https://github.com/Coolment-Content-Creation/SMP/assets/76031490/658e54d0-5703-4a11-aa0b-5b279fa73169)

has been converted to into a `player-settings.yml`.
![image](https://github.com/Coolment-Content-Creation/SMP/assets/76031490/ee3fb8b2-dde6-4878-aa0b-31cb2f951504)
Currently only trusts are in the player settings. 

_I know that in the future there will be a database for the trusts and any player settings, but this is a holdover until then._

The `trusts.yml` will be copied into a `player-settings.yml`. The old `trusts.yml` is not mutated in this process, and stays safe in case of any issues.